### PR TITLE
Change to source.python.3

### DIFF
--- a/Python3.sublime-build
+++ b/Python3.sublime-build
@@ -1,7 +1,7 @@
 {
     "shell_cmd": "python3 -OO -u \"$file\"",
     "file_regex": "^[ ]*File \"(...*?)\", line ([0-9]*)",
-    "selector": "source.python",
+    "selector": "source.python.3",
     "windows":
     {
         "shell_cmd": "py -3 -OO -u \"$file\""

--- a/Python3.tmLanguage
+++ b/Python3.tmLanguage
@@ -1171,7 +1171,7 @@
 		</dict>
 	</dict>
 	<key>scopeName</key>
-	<string>source.python3</string>
+	<string>source.python.3</string>
 	<key>uuid</key>
 	<string>851B1429-B8B4-4C1E-8030-399BDA994393</string>
 </dict>


### PR DESCRIPTION
Confirmed that:
1. When file syntax is set to the in-built "Python", Sublime uses the build-in Python build system (it uses the Python in your path).
2. When file syntax is set to "Python3", plugins that match on scope "source.python" continue to match, i.e., Anaconda works :).
3. Build selector is able to specifically match "source.python.3" and takes precedence over something that matches "source.python".
