### PR TITLE
Add spaces to after the hash (#) in comments

### DIFF
--- a/build.py
+++ b/build.py
@@ -70,7 +70,7 @@ from src.gloom   import style  as gl_style
 py_details = {'name' : 'Python3',
               'path' : LANG_PATH,
               'scope': 'python.3',
-              'comments' : {'lines': '#'},
+              'comments' : {'lines': '# '},
               'test_name': 'Python3_TEST',
               'test_path': '~/Library/Application Support/Sublime Text 3/'
                            'Packages/User/Python3_TEST'}
@@ -78,7 +78,7 @@ py_details = {'name' : 'Python3',
 cy_details = {'name' : 'Cython',
               'path' : LANG_PATH,
               'scope': 'cython',
-              'comments' : {'lines': '#'},
+              'comments' : {'lines': '# '},
               'test_name': 'Cython_TEST',
               'test_path': '~/Library/Application Support/Sublime Text 3/'
                            'Packages/User/Cython_TEST'}


### PR DESCRIPTION
Spaces after the hash (#) allow auto-wrappers that use .tmLanguage information to wrap text in a nicer format.