### PR TITLE
Fix lambda matching

### DIFF
--- a/src/common.py
+++ b/src/common.py
@@ -163,7 +163,7 @@ syntax = {
         0x0130:
         {
             'name' : 'meta.function.anonymous.{SCOPE}',
-            'begin': r'\b(lambda)',
+            'begin': r'\b(lambda)\b',
             'beginCaptures':
             {
                 1: {'name': 'storage.type.function.anonymous.{SCOPE}'}


### PR DESCRIPTION
I've been using your theme for a while now and ran into a problem where I tried to use a variable named like `lambda_var` and it got highlighted as if it was a `lambda`, when it was in fact just a variable. I added a word boundary to the end of the regex you use to check for the presence of a `lambda` to fix that problem.
